### PR TITLE
Replaced xml with defusedxml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,7 @@ classifiers = [
 homepage = "https://github.com/andersnauman/dmarc-parser"
 
 [build-system]
-requires = ["setuptools >= 61.0.0", "wheel"]
+requires = ["setuptools >= 61.0.0", "wheel", "defusedxml >= 0.7.1"]
 build-backend = "setuptools.build_meta"
 
 [tool.setuptools.packages.find]

--- a/src/dmarcparser/parser.py
+++ b/src/dmarcparser/parser.py
@@ -14,7 +14,7 @@ from email.message import EmailMessage
 from zipfile import ZipFile, BadZipFile
 from gzip import GzipFile, BadGzipFile
 
-import xml.etree.ElementTree as elementTree
+import defusedxml.ElementTree as elementTree
 
 from .logger import _custom_logger
 from .logger import SYSLOG_TO_SCREEN, SYSLOG_TO_FILE

--- a/src/dmarcparser/report.py
+++ b/src/dmarcparser/report.py
@@ -5,7 +5,7 @@
 
 import io
 import re
-import xml.etree.ElementTree as elementTree
+import defusedxml.ElementTree as elementTree
 
 from datetime import datetime
 from dataclasses import dataclass, asdict


### PR DESCRIPTION
For security reasons, it can be interesting to use xml library with defusedxml (https://pypi.org/project/defusedxml/).